### PR TITLE
admins/itemsの登録・編集が出来ないのを修正

### DIFF
--- a/app/controllers/admins/items_controller.rb
+++ b/app/controllers/admins/items_controller.rb
@@ -65,6 +65,10 @@ class Admins::ItemsController < ApplicationController
   end
 
   private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_item
+      @item = Item.find(params[:id])
+    end
 
     # Only allow a list of trusted parameters through.
     def item_params

--- a/app/controllers/admins/items_controller.rb
+++ b/app/controllers/admins/items_controller.rb
@@ -46,7 +46,7 @@ class Admins::ItemsController < ApplicationController
     respond_to do |format|
       if @item.update(item_params)
         format.html { redirect_to admins_item_url(@item), notice: "アイテムが更新されました" }
-        format.json { render :show, status: :ok, location: @item }
+        format.json { render :show, status: :ok, location: admins_item_url(@item) }
       else
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @item.errors, status: :unprocessable_entity }

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -18,7 +18,7 @@ class Admins::UsersController < ApplicationController
     respond_to do |format|
       if @user.save
         format.html { redirect_to user_url(@user), notice: "User was successfully created." }
-        format.json { render :show, status: :created, location: @user }
+        format.json { render :show, status: :created, location: user_url(@user) }
       else
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @user.errors, status: :unprocessable_entity }

--- a/app/controllers/api/v1/meals_controller.rb
+++ b/app/controllers/api/v1/meals_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::MealsController < ApplicationController
   # PATCH/PUT /api/v1/meals/1.json
   # def update
   #   if @meal.update(meal_params)
-  #     render :show, status: :ok, location: @meal
+  #     render :show, status: :ok
   #   else
   #     render json: @meal.errors, status: :unprocessable_entity
   #   end

--- a/app/controllers/api/v1/my_recipe_items_controller.rb
+++ b/app/controllers/api/v1/my_recipe_items_controller.rb
@@ -47,7 +47,7 @@ class Api::V1::MyRecipeItemsController < ApplicationController
   # PATCH/PUT /my_recipe_items/1.json
   # def update
   #   if @my_recipe_item.update(my_recipe_item_params)
-  #     render :show, status: :ok, location: @my_recipe_item
+  #     render :show, status: :ok
   #   else
   #     render json: @my_recipe_item.errors, status: :unprocessable_entity
   #   end

--- a/app/controllers/api/v1/weight_records_controller.rb
+++ b/app/controllers/api/v1/weight_records_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::WeightRecordsController < ApplicationController
   # PATCH/PUT /api/v1/weight_records/1.json
   # def update
   #   if @weight_record.update(weight_record_params)
-  #     render :show, status: :ok, location: @weight_record
+  #     render :show, status: :ok
   #   else
   #     render json: @weight_record.errors, status: :unprocessable_entity
   #   end

--- a/app/views/admins/users/index.json.jbuilder
+++ b/app/views/admins/users/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @users, partial: "users/user", as: :user
+json.array! @users, partial: "admins/users/user", as: :user

--- a/app/views/admins/users/show.json.jbuilder
+++ b/app/views/admins/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "users/user", user: @user
+json.partial! "admins/users/user", user: @user


### PR DESCRIPTION
Fix #48

- ついでに登録成功時に `render.json` ができてないのも直した
- admins/users も同様に直せそうなので直した
- json出力に `location` は要らない気がしなくもないけどとりま残しておく